### PR TITLE
Added fix for TagsGet

### DIFF
--- a/src/common/client/tags/client.go
+++ b/src/common/client/tags/client.go
@@ -65,7 +65,7 @@ func (m MainClient) TagsGet(name string) ([]tagapisdk.Tag, *http.Response, error
 	request := m.TagSdkClient.TagsGet(context.Background())
 
 	if name != "" {
-		request.Name(name)
+		request = request.Name(name)
 	}
 
 	return request.Execute()


### PR DESCRIPTION
`TagsGet` was ignoring the query parameters as `.Name(...)` returns the updated struct rather than updating inplace. Fixed with reassignment.