### PR TITLE
Fixed docgenerator makefile

### DIFF
--- a/docs/generation/Makefile
+++ b/docs/generation/Makefile
@@ -8,11 +8,13 @@ M = $(shell printf "\033[34;1m▶\033[0m")
 
 export GO111MODULE=on
 
-$(DOCS): main.go go.mod go.sum; $(info $(M) building docgenerator executable…) 
+.PHONY: generate-docs 
+generate-docs: build-docgenerator run-docgenerator
+
+build-docgenerator: main.go go.mod go.sum; $(info $(M) building docgenerator executable docs…) @
 	$Q $(GO) build -o $(DOCS) main.go
 
-.PHONY: generate-docs 
-generate-docs: $(DOCS) ; $(info $(M) generating docs…) @ ## Generate Commands documentation
+run-docgenerator: $(DOCS); $(info $(M) generating docs…) @
 	$Q ./$(DOCS)
 
 .PHONY: help


### PR DESCRIPTION
When `generate-docs` would be run, it would build the `docgenerator` executable and then run it. However, if you then _run it again_, the building step would be skipped.
This causes issues, as if you generate docs, update commands, then generate docs again, the docs wouldn't be updated since they reflect an outdated doc generator. 

This PR solves this issue by forcing the build step to run on every `generate-docs`.