### PR TITLE
Updated models for other APIs

### DIFF
--- a/src/common/models/billingmodels/productoneof/productcommon.go
+++ b/src/common/models/billingmodels/productoneof/productcommon.go
@@ -17,6 +17,7 @@ const (
 	// Product
 	BANDWIDTH        Discriminator = "BANDWIDTH"
 	OPERATING_SYSTEM Discriminator = "OPERATING_SYSTEM"
+	STORAGE          Discriminator = "STORAGE"
 )
 
 type ProductSdk interface {

--- a/src/common/models/billingmodels/productsoneof.go
+++ b/src/common/models/billingmodels/productsoneof.go
@@ -18,7 +18,7 @@ func ProductActualFromSdk(productOneOf billingapisdk.ProductsGet200ResponseInner
 	}
 
 	switch {
-	case productCommon.IsActually(BANDWIDTH, OPERATING_SYSTEM):
+	case productCommon.IsActually(BANDWIDTH, OPERATING_SYSTEM, STORAGE):
 		return &productCli
 	case productCommon.IsActually(SERVER):
 		return &ServerProduct{

--- a/src/common/models/billingmodels/productsoneof_test.go
+++ b/src/common/models/billingmodels/productsoneof_test.go
@@ -30,6 +30,16 @@ func TestProductActualFromSdk_OperatingSystemProduct(test_framework *testing.T) 
 	assertEqualAsProduct(test_framework, actual, *operatingSystemProduct)
 }
 
+func TestProductActualFromSdk_StorageProduct(test_framework *testing.T) {
+	storageProduct := GenerateStorageProduct()
+	ProductsResponse := billingapi.ProductsGet200ResponseInner{
+		Product: storageProduct,
+	}
+
+	actual := ProductActualFromSdk(ProductsResponse)
+	assertEqualAsProduct(test_framework, actual, *storageProduct)
+}
+
 func TestProductActualFromSdk_ServerProduct(test_framework *testing.T) {
 	serverProduct := GenerateServerProduct()
 	ProductsResponse := billingapi.ProductsGet200ResponseInner{

--- a/src/common/models/billingmodels/ratedusageoneof.go
+++ b/src/common/models/billingmodels/ratedusageoneof.go
@@ -41,6 +41,11 @@ func RatedUsageActualFromSdk(ratedUsageOneOf billingapisdk.RatedUsageGet200Respo
 			RatedUsageCommon: *ratedUsage,
 			Metadata:         *ServerDetailsFromSdk(&ratedUsageOneOf.ServerRecord.Metadata),
 		}
+	case ratedUsage.IsActually(STORAGE):
+		return &StorageRecord{
+			RatedUsageCommon: *ratedUsage,
+			Metadata:         *StorageDetailsFromSdk(&ratedUsageOneOf.StorageRecord.Metadata),
+		}
 	}
 
 	return nil

--- a/src/common/models/billingmodels/ratedusageoneof/ratedusage.go
+++ b/src/common/models/billingmodels/ratedusageoneof/ratedusage.go
@@ -22,6 +22,9 @@ const (
 
 	// Server Record
 	SERVER Discriminator = "bmc-server"
+
+	// Storage Record
+	STORAGE Discriminator = "storage"
 )
 
 // Matches all elements in the OneOf due to common fields.
@@ -34,6 +37,7 @@ type RatedUsageSdk interface {
 	GetStartDateTime() time.Time
 	GetEndDateTime() time.Time
 	GetCost() int64
+	GetCostDescription() string
 	GetPriceModel() string
 	GetUnitPrice() float32
 	GetUnitPriceDescription() string
@@ -54,6 +58,7 @@ type RatedUsageCommon struct {
 	StartDateTime        time.Time     `json:"startDateTime" yaml:"startDateTime"`
 	EndDateTime          time.Time     `json:"endDateTime" yaml:"endDateTime"`
 	Cost                 int64         `json:"cost" yaml:"cost"`
+	CostDescription      string        `json:"costDescription" yaml:"costDescription"`
 	PriceModel           string        `json:"priceModel" yaml:"priceModel"`
 	UnitPrice            float32       `json:"unitPrice" yaml:"unitPrice"`
 	UnitPriceDescription string        `json:"unitPriceDescription" yaml:"unitPriceDescription"`
@@ -81,6 +86,7 @@ func RatedUsageFromSdkOneOf(sdk *billingapisdk.RatedUsageGet200ResponseInner) *R
 		StartDateTime:        actualInstance.GetStartDateTime(),
 		EndDateTime:          actualInstance.GetEndDateTime(),
 		Cost:                 actualInstance.GetCost(),
+		CostDescription:      actualInstance.GetCostDescription(),
 		PriceModel:           actualInstance.GetPriceModel(),
 		UnitPrice:            actualInstance.GetUnitPrice(),
 		UnitPriceDescription: actualInstance.GetUnitPriceDescription(),

--- a/src/common/models/billingmodels/ratedusageoneof/records.go
+++ b/src/common/models/billingmodels/ratedusageoneof/records.go
@@ -1,6 +1,10 @@
 package ratedusageoneof
 
-import "github.com/phoenixnap/go-sdk-bmc/billingapi"
+import (
+	"time"
+
+	"github.com/phoenixnap/go-sdk-bmc/billingapi"
+)
 
 // Record types
 type BandwidthRecord struct {
@@ -21,6 +25,11 @@ type PublicSubnetRecord struct {
 type ServerRecord struct {
 	RatedUsageCommon
 	Metadata ServerDetails `json:"metadata" yaml:"metadata"`
+}
+
+type StorageRecord struct {
+	RatedUsageCommon
+	Metadata StorageDetails `json:"metadata" yaml:"metadata"`
 }
 
 // Metadata
@@ -75,5 +84,25 @@ func ServerDetailsFromSdk(serverDetails *billingapi.ServerDetails) *ServerDetail
 	return &ServerDetails{
 		Id:       serverDetails.Id,
 		Hostname: serverDetails.Hostname,
+	}
+}
+
+type StorageDetails struct {
+	NetworkStorageId   string    `json:"networkStorageId" yaml:"networkStorageId"`
+	NetworkStorageName string    `json:"networkStorageName" yaml:"networkStorageName"`
+	VolumeId           string    `json:"volumeId" yaml:"volumeId"`
+	VolumeName         string    `json:"volumeName" yaml:"volumeName"`
+	CapacityInGb       int64     `json:"capacityInGb" yaml:"capacityInGb"`
+	CreatedOn          time.Time `json:"createdOn" yaml:"createdOn"`
+}
+
+func StorageDetailsFromSdk(storageDetails *billingapi.StorageDetails) *StorageDetails {
+	return &StorageDetails{
+		NetworkStorageId:   storageDetails.NetworkStorageId,
+		NetworkStorageName: storageDetails.NetworkStorageName,
+		VolumeId:           storageDetails.VolumeId,
+		VolumeName:         storageDetails.VolumeName,
+		CapacityInGb:       storageDetails.CapacityInGb,
+		CreatedOn:          storageDetails.CreatedOn,
 	}
 }

--- a/src/common/models/billingmodels/ratedusageoneof_test.go
+++ b/src/common/models/billingmodels/ratedusageoneof_test.go
@@ -49,6 +49,16 @@ func TestRatedUsageActualFromSdk_ServerRecord(test_framework *testing.T) {
 	assertEqualAsServerRecord(test_framework, actual, *serverRecord)
 }
 
+func TestRatedUsageActualFromSdk_StorageRecord(test_framework *testing.T) {
+	storageRecord := GenerateStorageRecordSdk()
+	ratedUsageResponse := billingapi.RatedUsageGet200ResponseInner{
+		StorageRecord: storageRecord,
+	}
+
+	actual := RatedUsageActualFromSdk(ratedUsageResponse)
+	assertEqualAsStorageRecord(test_framework, actual, *storageRecord)
+}
+
 // Equality asserts
 
 func assertEqualAsBandwidthRecord(
@@ -164,4 +174,36 @@ func assertEqualAsServerRecord(
 
 	assert.Equal(test_framework, cliServer.Metadata.Id, sdkServer.Metadata.Id)
 	assert.Equal(test_framework, cliServer.Metadata.Hostname, sdkServer.Metadata.Hostname)
+}
+
+func assertEqualAsStorageRecord(
+	test_framework *testing.T,
+	cliOneOf interface{},
+	sdkStorage billingapi.StorageRecord,
+) {
+	cliServer := cliOneOf.(*ratedusageoneof.StorageRecord)
+
+	assert.Equal(test_framework, cliServer.Id, sdkStorage.GetId())
+	assert.Equal(test_framework, string(cliServer.ProductCategory), sdkStorage.GetProductCategory())
+	assert.Equal(test_framework, cliServer.ProductCode, sdkStorage.GetProductCode())
+	assert.Equal(test_framework, billingapi.LocationEnum(cliServer.Location), sdkStorage.GetLocation())
+	assert.Equal(test_framework, cliServer.YearMonth, sdkStorage.GetYearMonth())
+	assert.Equal(test_framework, cliServer.StartDateTime, sdkStorage.GetStartDateTime())
+	assert.Equal(test_framework, cliServer.EndDateTime, sdkStorage.GetEndDateTime())
+	assert.Equal(test_framework, cliServer.Cost, sdkStorage.GetCost())
+	assert.Equal(test_framework, cliServer.PriceModel, sdkStorage.GetPriceModel())
+	assert.Equal(test_framework, cliServer.UnitPrice, sdkStorage.GetUnitPrice())
+	assert.Equal(test_framework, cliServer.UnitPriceDescription, sdkStorage.GetUnitPriceDescription())
+	assert.Equal(test_framework, cliServer.Quantity, sdkStorage.GetQuantity())
+	assert.Equal(test_framework, cliServer.Active, sdkStorage.GetActive())
+	assert.Equal(test_framework, cliServer.UsageSessionId, sdkStorage.GetUsageSessionId())
+	assert.Equal(test_framework, cliServer.CorrelationId, sdkStorage.GetCorrelationId())
+	assert.Equal(test_framework, cliServer.ReservationId, sdkStorage.GetReservationId())
+
+	assert.Equal(test_framework, cliServer.Metadata.NetworkStorageId, sdkStorage.Metadata.NetworkStorageId)
+	assert.Equal(test_framework, cliServer.Metadata.NetworkStorageName, sdkStorage.Metadata.NetworkStorageName)
+	assert.Equal(test_framework, cliServer.Metadata.VolumeId, sdkStorage.Metadata.VolumeId)
+	assert.Equal(test_framework, cliServer.Metadata.VolumeName, sdkStorage.Metadata.VolumeName)
+	assert.Equal(test_framework, cliServer.Metadata.CapacityInGb, sdkStorage.Metadata.CapacityInGb)
+	assert.Equal(test_framework, cliServer.Metadata.CreatedOn, sdkStorage.Metadata.CreatedOn)
 }

--- a/src/common/models/billingmodels/testutil_billinggenerator.go
+++ b/src/common/models/billingmodels/testutil_billinggenerator.go
@@ -145,6 +145,25 @@ func GenerateServerDetails() billingapi.ServerDetails {
 	}
 }
 
+func GenerateStorageRecordSdk() *billingapi.StorageRecord {
+	record := billingapi.StorageRecord{
+		ProductCategory: string(ratedusageoneof.STORAGE),
+		Metadata:        GenerateStorageDetails(),
+	}
+	return populateRatedUsageCommon(&record).(*billingapi.StorageRecord)
+}
+
+func GenerateStorageDetails() billingapi.StorageDetails {
+	return billingapi.StorageDetails{
+		NetworkStorageId:   testutil.RandSeq(10),
+		NetworkStorageName: testutil.RandSeq(10),
+		VolumeId:           testutil.RandSeq(10),
+		VolumeName:         testutil.RandSeq(10),
+		CapacityInGb:       rand.Int63(),
+		CreatedOn:          time.Now(),
+	}
+}
+
 // Products
 func GenerateProductsGetQueryParams() ProductsGetQueryParams {
 	return ProductsGetQueryParams{
@@ -207,6 +226,14 @@ func GenerateBandwidthProduct() *billingapi.Product {
 func GenerateOperatingSystemProduct() *billingapi.Product {
 	product := &billingapi.Product{
 		ProductCategory: string(productoneof.OPERATING_SYSTEM),
+	}
+
+	return populateProductCommon(product).(*billingapi.Product)
+}
+
+func GenerateStorageProduct() *billingapi.Product {
+	product := &billingapi.Product{
+		ProductCategory: string(productoneof.STORAGE),
 	}
 
 	return populateProductCommon(product).(*billingapi.Product)

--- a/src/common/models/bmcapimodels/servermodels/osconfiguration.go
+++ b/src/common/models/bmcapimodels/servermodels/osconfiguration.go
@@ -9,6 +9,7 @@ type OsConfiguration struct {
 	RootPassword               *string                 `yaml:"rootPassword,omitempty" json:"rootPassword,omitempty"`
 	ManagementUiUrl            *string                 `yaml:"managementUiUrl,omitempty" json:"managementUiUrl,omitempty"`
 	ManagementAccessAllowedIps []string                `yaml:"managementAccessAllowedIps,omitempty" json:"managementAccessAllowedIps,omitempty"`
+	InstallOsToRam             *bool                   `yaml:"installOsToRam,omitempty" json:"installOsToRam,omitempty"`
 }
 
 func (osConfiguration *OsConfiguration) toSdk() *bmcapisdk.OsConfiguration {
@@ -21,6 +22,7 @@ func (osConfiguration *OsConfiguration) toSdk() *bmcapisdk.OsConfiguration {
 		RootPassword:               osConfiguration.RootPassword,
 		ManagementUiUrl:            osConfiguration.ManagementUiUrl,
 		ManagementAccessAllowedIps: osConfiguration.ManagementAccessAllowedIps,
+		InstallOsToRam:             osConfiguration.InstallOsToRam,
 	}
 }
 
@@ -34,6 +36,7 @@ func osConfigurationFromSdk(osConfiguration *bmcapisdk.OsConfiguration) *OsConfi
 		RootPassword:               osConfiguration.RootPassword,
 		ManagementUiUrl:            osConfiguration.ManagementUiUrl,
 		ManagementAccessAllowedIps: osConfiguration.ManagementAccessAllowedIps,
+		InstallOsToRam:             osConfiguration.InstallOsToRam,
 	}
 }
 

--- a/src/common/models/bmcapimodels/servermodels/osconfiguration_test.go
+++ b/src/common/models/bmcapimodels/servermodels/osconfiguration_test.go
@@ -88,6 +88,7 @@ func assertEqualOsConfiguration(test_framework *testing.T, cliOsConfiguration Os
 
 	assert.Equal(test_framework, cliOsConfiguration.RootPassword, sdkOsConfiguration.RootPassword)
 	assert.Equal(test_framework, cliOsConfiguration.ManagementUiUrl, sdkOsConfiguration.ManagementUiUrl)
+	assert.Equal(test_framework, cliOsConfiguration.InstallOsToRam, sdkOsConfiguration.InstallOsToRam)
 
 	if testutil.AssertNilEquality(test_framework, "Management Access Allowed IPs", cliOsConfiguration.ManagementAccessAllowedIps, sdkOsConfiguration.ManagementAccessAllowedIps) {
 		assert.Equal(test_framework, len(cliOsConfiguration.ManagementAccessAllowedIps), len(sdkOsConfiguration.ManagementAccessAllowedIps))

--- a/src/common/models/networkmodels/privatenetwork.go
+++ b/src/common/models/networkmodels/privatenetwork.go
@@ -19,6 +19,7 @@ type PrivateNetwork struct {
 	Servers         []PrivateNetworkServer `json:"server" yaml:"server"`
 	Memberships     []NetworkMembership    `json:"memberships" yaml:"memberships"`
 	CreatedOn       time.Time              `json:"createdOn" yaml:"createdOn"`
+	Status          string                 `json:"status" yaml:"status"`
 }
 
 func PrivateNetworkFromSdk(network networksdk.PrivateNetwork) PrivateNetwork {
@@ -40,5 +41,6 @@ func PrivateNetworkFromSdk(network networksdk.PrivateNetwork) PrivateNetwork {
 		Servers:         servers,
 		Memberships:     iterutils.Map(network.Memberships, NetworkMembershipFromSdk),
 		CreatedOn:       network.CreatedOn,
+		Status:          network.Status,
 	}
 }

--- a/src/common/models/networkmodels/privatenetwork_test.go
+++ b/src/common/models/networkmodels/privatenetwork_test.go
@@ -27,6 +27,7 @@ func assertEqualPrivateNetwork(test_framework *testing.T, p1 PrivateNetwork, p2 
 	assert.Equal(test_framework, p1.LocationDefault, p2.LocationDefault)
 	assert.Equal(test_framework, p1.Cidr, p2.Cidr)
 	assert.Equal(test_framework, p1.CreatedOn, p2.CreatedOn)
+	assert.Equal(test_framework, p1.Status, p2.Status)
 
 	testutil.ForEachPair(p1.Servers, p2.Servers).
 		Do(test_framework, assertEqualPrivateNetworkServer)

--- a/src/common/models/tables/producttable.go
+++ b/src/common/models/tables/producttable.go
@@ -53,7 +53,7 @@ func parseCommonProduct(sdk billingapisdk.ProductsGet200ResponseInner) *ProductT
 
 func (p *ProductTable) attachUnique(sdk billingapisdk.ProductsGet200ResponseInner) {
 	switch p.ProductCategory {
-	case productoneof.BANDWIDTH, productoneof.OPERATING_SYSTEM:
+	case productoneof.BANDWIDTH, productoneof.OPERATING_SYSTEM, productoneof.STORAGE:
 		return
 	case productoneof.SERVER:
 		p.Metadata = map[string]interface{}{

--- a/src/common/models/tables/producttable_test.go
+++ b/src/common/models/tables/producttable_test.go
@@ -31,6 +31,16 @@ func TestProductActualFromSdk_OperatingSystemProduct(test_framework *testing.T) 
 	assertEqualAsProduct(test_framework, *operatingSystemProduct, *actual)
 }
 
+func TestProductActualFromSdk_StorageProduct(test_framework *testing.T) {
+	storageProduct := billingmodels.GenerateStorageProduct()
+	ProductsResponse := billingapi.ProductsGet200ResponseInner{
+		Product: storageProduct,
+	}
+
+	actual := ProductTableFromSdk(ProductsResponse)
+	assertEqualAsProduct(test_framework, *storageProduct, *actual)
+}
+
 func TestProductActualFromSdk_ServerProduct(test_framework *testing.T) {
 	serverProduct := billingmodels.GenerateServerProduct()
 	ProductsResponse := billingapi.ProductsGet200ResponseInner{

--- a/src/common/models/tables/ratedusagerecordtable.go
+++ b/src/common/models/tables/ratedusagerecordtable.go
@@ -32,6 +32,14 @@ const (
 	// Server Record
 	SERVER_ID = "Server Id"
 	HOSTNAME  = "Hostname"
+
+	// Storage Record
+	NETWORK_STORAGE_ID   = "Network Storage ID"
+	NETWORK_STORAGE_NAME = "Network Storage Name"
+	VOLUME_ID            = "Volume ID"
+	VOLUME_NAME          = "Volume Name"
+	CAPACITY_IN_GB       = "Capacity (GB)"
+	CREATED_ON           = "Created On"
 )
 
 // Full Table
@@ -121,6 +129,16 @@ func (table *RatedUsageRecordTable) attachUnique(sdk billingapisdk.RatedUsageGet
 		table.Metadata = map[string]interface{}{
 			SERVER_ID: sdk.ServerRecord.Metadata.Id,
 			HOSTNAME:  sdk.ServerRecord.Metadata.Hostname,
+		}
+
+	case ratedusageoneof.STORAGE:
+		table.Metadata = map[string]interface{}{
+			NETWORK_STORAGE_ID:   sdk.StorageRecord.Metadata.NetworkStorageId,
+			NETWORK_STORAGE_NAME: sdk.StorageRecord.Metadata.NetworkStorageName,
+			VOLUME_ID:            sdk.StorageRecord.Metadata.VolumeId,
+			VOLUME_NAME:          sdk.StorageRecord.Metadata.VolumeName,
+			CAPACITY_IN_GB:       sdk.StorageRecord.Metadata.CapacityInGb,
+			CREATED_ON:           sdk.StorageRecord.Metadata.CreatedOn,
 		}
 	}
 }

--- a/src/common/models/tables/ratedusagerecordtable_test.go
+++ b/src/common/models/tables/ratedusagerecordtable_test.go
@@ -45,6 +45,15 @@ func TestRatedUsageRecordFromServerSdk(test_framework *testing.T) {
 	assertFullServerRecordsEqual(test_framework, *record.ServerRecord, table)
 }
 
+func TestRatedUsageRecordFromStorageSdk(test_framework *testing.T) {
+	record := billingapi.RatedUsageGet200ResponseInner{
+		StorageRecord: billingmodels.GenerateStorageRecordSdk(),
+	}
+	table := *RatedUsageRecordTableFromSdk(record)
+
+	assertFullStorageRecordsEqual(test_framework, *record.StorageRecord, table)
+}
+
 // Full assertions
 func assertFullBandwidthRecordsEqual(test_framework *testing.T, bandwidthRecord billingapi.BandwidthRecord, cliOneOf RatedUsageRecordTable) {
 	assert.Equal(test_framework, bandwidthRecord.Id, cliOneOf.Id)
@@ -135,4 +144,30 @@ func assertFullServerRecordsEqual(test_framework *testing.T, serverRecord billin
 
 	assert.Equal(test_framework, serverRecord.Metadata.Hostname, cliOneOf.Metadata[HOSTNAME])
 	assert.Equal(test_framework, serverRecord.Metadata.Id, cliOneOf.Metadata[SERVER_ID])
+}
+
+func assertFullStorageRecordsEqual(test_framework *testing.T, storageRecord billingapi.StorageRecord, cliOneOf RatedUsageRecordTable) {
+	assert.Equal(test_framework, storageRecord.Id, cliOneOf.Id)
+	assert.Equal(test_framework, storageRecord.ProductCategory, string(cliOneOf.ProductCategory))
+	assert.Equal(test_framework, storageRecord.ProductCode, cliOneOf.ProductCode)
+	assert.Equal(test_framework, string(storageRecord.Location), cliOneOf.Location)
+	assert.Equal(test_framework, DerefString(storageRecord.YearMonth), cliOneOf.YearMonth)
+	assert.Equal(test_framework, storageRecord.StartDateTime.String(), cliOneOf.StartDateTime)
+	assert.Equal(test_framework, storageRecord.EndDateTime.String(), cliOneOf.EndDateTime)
+	assert.Equal(test_framework, storageRecord.Cost, cliOneOf.Cost)
+	assert.Equal(test_framework, storageRecord.PriceModel, cliOneOf.PriceModel)
+	assert.Equal(test_framework, storageRecord.UnitPrice, cliOneOf.UnitPrice)
+	assert.Equal(test_framework, storageRecord.UnitPriceDescription, cliOneOf.UnitPriceDescription)
+	assert.Equal(test_framework, storageRecord.Quantity, cliOneOf.Quantity)
+	assert.Equal(test_framework, storageRecord.Active, cliOneOf.Active)
+	assert.Equal(test_framework, storageRecord.UsageSessionId, cliOneOf.UsageSessionId)
+	assert.Equal(test_framework, storageRecord.CorrelationId, cliOneOf.CorrelationId)
+	assert.Equal(test_framework, DerefString(storageRecord.ReservationId), cliOneOf.ReservationId)
+
+	assert.Equal(test_framework, storageRecord.Metadata.NetworkStorageId, cliOneOf.Metadata[NETWORK_STORAGE_ID])
+	assert.Equal(test_framework, storageRecord.Metadata.NetworkStorageName, cliOneOf.Metadata[NETWORK_STORAGE_NAME])
+	assert.Equal(test_framework, storageRecord.Metadata.VolumeId, cliOneOf.Metadata[VOLUME_ID])
+	assert.Equal(test_framework, storageRecord.Metadata.VolumeName, cliOneOf.Metadata[VOLUME_NAME])
+	assert.Equal(test_framework, storageRecord.Metadata.CapacityInGb, cliOneOf.Metadata[CAPACITY_IN_GB])
+	assert.Equal(test_framework, storageRecord.Metadata.CreatedOn, cliOneOf.Metadata[CREATED_ON])
 }

--- a/src/common/printer/printer_test.go
+++ b/src/common/printer/printer_test.go
@@ -498,6 +498,18 @@ func TestPrepareRatedUsageRecordForPrintingNonTable_Server(test_framework *testi
 	assert.Equal(test_framework, outputType, "*ratedusageoneof.ServerRecord")
 }
 
+func TestPrepareRatedUsageRecordForPrintingNonTable_Storage(test_framework *testing.T) {
+	OutputFormat = "json"
+	ratedUsage := billingapi.RatedUsageGet200ResponseInner{
+		StorageRecord: billingmodels.GenerateStorageRecordSdk(),
+	}
+	prepared := PrepareRatedUsageForPrinting(ratedUsage, true)
+
+	outputType := fmt.Sprintf("%T", prepared)
+
+	assert.Equal(test_framework, outputType, "*ratedusageoneof.StorageRecord")
+}
+
 func TestPrepareRatedUsageRecordForPrintingNonTable_Short(test_framework *testing.T) {
 	OutputFormat = "json"
 	ratedUsage := billingapi.RatedUsageGet200ResponseInner{
@@ -550,6 +562,18 @@ func TestPrepareProductForPrintingNonTable_OperatingSystemProduct(test_framework
 	OutputFormat = "json"
 	product := billingapi.ProductsGet200ResponseInner{
 		Product: billingmodels.GenerateOperatingSystemProduct(),
+	}
+	prepared := PrepareProductForPrinting(product)
+
+	outputType := fmt.Sprintf("%T", prepared)
+
+	assert.Equal(test_framework, outputType, "*productoneof.Product")
+}
+
+func TestPrepareProductForPrintingNonTable_StorageProduct(test_framework *testing.T) {
+	OutputFormat = "json"
+	product := billingapi.ProductsGet200ResponseInner{
+		Product: billingmodels.GenerateStorageProduct(),
 	}
 	prepared := PrepareProductForPrinting(product)
 


### PR DESCRIPTION
Already implemented commands had their models updated.
- Added support for Products and Rated Usages of type "STORAGE"
- Added `installOsToRam` to `OsConfiguration`.
- Added `status` to `PrivateNetwork`.