### PR TITLE
Removed "created release" trigger from release workflow

### DIFF
--- a/.github/workflows/release-workflow.yml
+++ b/.github/workflows/release-workflow.yml
@@ -3,7 +3,6 @@ name: Release workflow
 on:
   release:
     types:
-      - created
       - published
       - edited
 


### PR DESCRIPTION
Instead, it should now only trigger when a release is *published*